### PR TITLE
[DOC,MNT,BUG] Documentation and testing for downsample.py

### DIFF
--- a/aeon_neuro/transformations/downsample.py
+++ b/aeon_neuro/transformations/downsample.py
@@ -8,7 +8,7 @@ def downsample_series(X, sfreq, target_sample_rate):
 
     Parameters
     ----------
-    X : a numpy array of shape = [n_instances, n_dimensions, n_timepoints]
+    X : a numpy array of shape = [n_cases, n_channels, n_timepoints]
         The input time series data to be downsampled.
     sfreq : int
         The original sampling frequency of the time series data.
@@ -18,15 +18,15 @@ def downsample_series(X, sfreq, target_sample_rate):
     Returns
     -------
     downsampled : a numpy array of
-        shape = [n_instances, n_dimensions, updated_timepoints]
+        shape = [n_cases, n_channels, updated_timepoints]
         The downsampled time series data.
     """
     new_ratio = int(sfreq / target_sample_rate)
-    n_instances, n_dimensions, n_timepoints = np.shape(X)
+    n_cases, n_channels, n_timepoints = np.shape(X)
     updated_timepoints = int(np.ceil(n_timepoints / new_ratio))
-    downsampled_data = np.zeros((n_instances, n_dimensions, updated_timepoints))
-    for i in range(n_instances):
-        for j in range(n_dimensions):
+    downsampled_data = np.zeros((n_cases, n_channels, updated_timepoints))
+    for i in range(n_cases):
+        for j in range(n_channels):
             updated_index = 0
             for k in range(0, n_timepoints, new_ratio):
                 downsampled_data[i][j][updated_index] = X[i][j][k]

--- a/aeon_neuro/transformations/downsample.py
+++ b/aeon_neuro/transformations/downsample.py
@@ -1,11 +1,30 @@
+"""downsample_series by frequency."""
+
 import numpy as np
 
 
 def downsample_series(X, sfreq, target_sample_rate):
+    """Downsample a time series.
+
+    Parameters
+    ----------
+    X : a numpy array of shape = [n_instances, n_dimensions, n_timepoints]
+        The input time series data to be downsampled.
+    sfreq : int
+        The original sampling frequency of the time series data.
+    target_sample_rate : int
+        The target sampling frequency after downsampling.
+
+    Returns
+    -------
+    downsampled : a numpy array of
+        shape = [n_instances, n_dimensions, updated_timepoints]
+        The downsampled time series data.
+    """
     new_ratio = int(sfreq / target_sample_rate)
     n_instances, n_dimensions, n_timepoints = np.shape(X)
-    updated_timepoints = int(n_timepoints / new_ratio)
-    downsampled_data = np.zeros((n_instances, n_dimensions, updated_timepoints + 1))
+    updated_timepoints = int(np.ceil(n_timepoints / new_ratio))
+    downsampled_data = np.zeros((n_instances, n_dimensions, updated_timepoints))
     for i in range(n_instances):
         for j in range(n_dimensions):
             updated_index = 0

--- a/aeon_neuro/transformations/downsample.py
+++ b/aeon_neuro/transformations/downsample.py
@@ -1,4 +1,4 @@
-"""downsample_series by frequency."""
+"""Downsample series by frequency."""
 
 import numpy as np
 

--- a/aeon_neuro/transformations/tests/__init__.py
+++ b/aeon_neuro/transformations/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests of transformations."""

--- a/aeon_neuro/transformations/tests/test_downsample.py
+++ b/aeon_neuro/transformations/tests/test_downsample.py
@@ -1,0 +1,46 @@
+"""Tests for downsample_series."""
+
+import numpy as np
+import pytest
+
+from aeon_neuro.transformations.downsample import downsample_series
+
+X = np.array(
+    [
+        [[1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]],
+        [
+            [10, 20, 30, 40, 50, 60, 70, 80, 90, 100],
+            [100, 90, 80, 70, 60, 50, 40, 30, 20, 10],
+        ],
+    ]
+)
+
+testdata = [
+    (
+        X,
+        10,
+        5,
+        np.array(
+            [
+                [[1, 3, 5, 7, 9], [10, 8, 6, 4, 2]],
+                [[10, 30, 50, 70, 90], [100, 80, 60, 40, 20]],
+            ]
+        ),
+    ),
+    (
+        X,
+        10,
+        3,
+        np.array(
+            [[[1, 4, 7, 10], [10, 7, 4, 1]], [[10, 40, 70, 100], [100, 70, 40, 10]]]
+        ),
+    ),
+    (X, 10, 2, np.array([[[1, 6], [10, 5]], [[10, 60], [100, 50]]])),
+]
+
+
+@pytest.mark.parametrize("X, sfreq, target_sample_rate, expected", testdata)
+def test_downsample_series(X, sfreq, target_sample_rate, expected):
+    """Test the downsampling of a time series."""
+    result = downsample_series(X, sfreq, target_sample_rate)
+    np.testing.assert_array_equal(result, expected)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at our
contribution guide: https://www.aeon-toolkit.org/en/stable/contributing.html

Feel free to delete sections of this template if they do not apply to your PR,
avoid submitting a blank template or empty sections.
-->

#### Reference Issues/PRs
Fixes #36 
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.
1.Fixe a bug in downsample.py when n_timepoints / new_ratio is an integer 
2.Complete a testing for downsample.py in transformations/tests/test_downsample.py 
3.Write documentation for transformations/downsample.py
<!--
A clear and concise description of what you have implemented.
-->

#### Does your contribution introduce a new dependency? If yes, which one?
no
<!--
If your contribution does add a dependency, we may suggest adding it as an
optional/soft dependency to keep external dependencies of the core aeon package
to a minimum.
-->

#### Any other comments?
no
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value all
user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
-->

### PR checklist

<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/aeon-toolkit/aeon-neuro/blob/main/.all-contributorsrc). Alternatively, you can use the [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot to do this for you.
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

##### For new estimators and functions
- [ ] I've added the estimator to the online API documentation.

##### For developers with write access
- [ ] Optionally, I've updated aeon's [CODEOWNERS](https://github.com/aeon-toolkit/aeon-neuro/blob/main/CODEOWNERS) to receive notifications about future changes to these files.


<!--
Thanks for contributing!
-->
