### PR TITLE
[ENH] Implement BandPowerSeriesTransformer

### DIFF
--- a/aeon_neuro/transformations/bandpower.py
+++ b/aeon_neuro/transformations/bandpower.py
@@ -1,9 +1,29 @@
+"""Band power transformations."""
+
 import numpy as np
 from scipy.fft import rfft, rfftfreq
 from scipy.integrate import simps
 
 
 class BandpowerExtraction:
+    """Band power transformer.
+
+    EEG signals occupy the frequency range of 0 − 60Hz,
+    which is roughly divided into five constituent physiological EEG sub bands:
+    δ (0 − 4Hz), θ (4 − 7Hz), α (8 − 12Hz), β (13 − 30Hz), and γ (30 − 60Hz).
+
+    Parameters
+    ----------
+    fs : int or float
+        Sampling frequency in Hz (samples per second).
+    band : str
+        The frequency band in {"delta", "theta", "alpha", "beta", "gamma"}.
+    window_width : int, optional
+        The width of the sliding window in number of samples, by default 1000.
+    window_space : int, optional
+        The space between the start of each window in number of samples, by default 5.
+    """
+
     def __init__(self, fs, band, window_width=1000, window_space=5):
         self.fs = fs
         self.band = band
@@ -11,6 +31,20 @@ class BandpowerExtraction:
         self.window_space = window_space
 
     def transform(self, X, y=None):
+        """Transform the input collection to extract band power features.
+
+        Parameters
+        ----------
+        X : list or np.ndarray of shape (n_cases, n_channels, n_timepoints)
+            Input time series collection.
+        y : None
+            Ignored for interface compatibility, by default None.
+
+        Returns
+        -------
+        np.ndarray of shape (n_cases, n_channels, n_windows)
+            The band power features for a given frequency band.
+        """
         max_freq, min_freq = selectBandFreqs(self.band)
         n_instances, n_channels, n_timepoints = np.shape(X)
         final_data = np.zeros(
@@ -23,7 +57,9 @@ class BandpowerExtraction:
         for instance in range(n_instances):
             for channel in range(n_channels):
                 for timepoint in range(
-                    1, n_timepoints - self.window_width, self.window_space
+                    1,
+                    n_timepoints - self.window_width,
+                    self.window_space,
                 ):
                     w = X[instance][channel][timepoint : timepoint + self.window_width]
                     coefficients = rfft(w)[1:]
@@ -38,15 +74,16 @@ class BandpowerExtraction:
 
 
 def selectBandFreqs(band):
+    """Return (max, min) frequency for given frequency band."""
     if band == "delta":
         return 4, 0
     elif band == "theta":
-        return 8, 4
+        return 7, 4
     elif band == "alpha":
         return 12, 8
     elif band == "beta":
-        return 30, 12
+        return 30, 13
     elif band == "gamma":
-        return 100, 30
+        return 60, 30
     else:
-        return 100, 0
+        return 60, 0

--- a/aeon_neuro/transformations/bandpower.py
+++ b/aeon_neuro/transformations/bandpower.py
@@ -2,8 +2,9 @@
 
 import numpy as np
 from aeon.transformations.series.base import BaseSeriesTransformer
+from aeon.utils.validation import check_n_jobs
+from mne.time_frequency import psd_array_welch
 from scipy.integrate import simpson
-from scipy.signal import welch
 
 
 class BandPowerSeriesTransformer(BaseSeriesTransformer):
@@ -12,25 +13,23 @@ class BandPowerSeriesTransformer(BaseSeriesTransformer):
     EEG signals occupy the frequency range of 0 - 60Hz,
     which is roughly divided into five constituent physiological EEG sub bands:
     δ (0 - 4Hz), θ (4 - 7Hz), α (8 - 12Hz), β (13 - 30Hz), and γ (30 - 60Hz).
-    Power within each frequency band is estimated using Welch's method,
-    which averages over windowed FFTs.
+    Power within each frequency band is estimated over time using windowed FFTs,
+    then averaged across channels.
 
     Parameters
     ----------
     sfreq : int or float
         Sampling frequency in Hz, by default 1.0.
     n_per_seg : int, optional
-        Length of each Welch segment in number of timepoints, by default 256.
-    n_overlap : int, optional
-        Number of timepoints to overlap between segments, by default 0.
+        Length of each segment/window in number of timepoints, by default 256.
     window : str, optional
         Windowing function to use. See `scipy.signal.get_window()`
         for a list of available windows, by default "hamming".
-    average : "mean" or "median", optional
-        Method to use when averaging Welch segments, by default "mean".
     relative : bool, optional
         If True, return the relative power (divide by total power across freq bands).
         If False, return the absolute power in V^2/Hz, by default True.
+    n_jobs : int, optional
+        Number of jobs to calculate power spectral densities, by default 1.
     """
 
     _tags = {
@@ -38,7 +37,7 @@ class BandPowerSeriesTransformer(BaseSeriesTransformer):
         "fit_is_empty": True,
     }
 
-    freq_bands = {
+    FREQ_BANDS = {
         "delta": (0, 4),
         "theta": (4, 7),
         "alpha": (8, 12),
@@ -50,18 +49,16 @@ class BandPowerSeriesTransformer(BaseSeriesTransformer):
         self,
         sfreq=1.0,  # scipy default
         n_per_seg=256,  # mne/scipy default, for window=str
-        n_overlap=0,  # mne default
         window="hamming",  # mne default
-        average="mean",  # scipy/mne default
         relative=True,
+        n_jobs=1,
     ):
         super().__init__(axis=1)  # (n_channels, n_timepoints)
         self.sfreq = sfreq
         self.n_per_seg = n_per_seg
-        self.n_overlap = n_overlap
         self.window = window
-        self.average = average
         self.relative = relative
+        self.n_jobs = check_n_jobs(n_jobs)
 
     def _transform(self, X, y=None):
         """Transform the input series to extract band power series.
@@ -75,34 +72,35 @@ class BandPowerSeriesTransformer(BaseSeriesTransformer):
 
         Returns
         -------
-        np.ndarray of shape (n_channels, 5_bands)
-            Power within δ, θ, α, β, and γ bands for each channel.
+        np.ndarray of shape (5_bands, int(n_timepoints/n_per_seg))
+            Power within δ, θ, α, β, and γ bands over time.
         """
         # next power of 2, for FFT efficiency
         n_fft = int(2 ** np.ceil(np.log2(self.n_per_seg)))
-        freqs, powers = welch(
+        powers, freqs = psd_array_welch(
             X,
-            fs=self.sfreq,
+            sfreq=self.sfreq,
+            fmin=self.FREQ_BANDS["delta"][0],
+            fmax=self.FREQ_BANDS["gamma"][1],
+            n_fft=n_fft,
+            n_overlap=0,
+            n_per_seg=self.n_per_seg,
+            n_jobs=self.n_jobs,
+            average=None,
             window=self.window,
-            nperseg=self.n_per_seg,
-            noverlap=self.n_overlap,
-            nfft=n_fft,
-            scaling="density",  # V^2/Hz
-            axis=-1,
-            average=self.average,
         )
 
         freq_res = freqs[1] - freqs[0]
 
-        band_powers = np.zeros(shape=(len(powers), len(self.freq_bands)))
-        for band_idx, (min_freq, max_freq) in enumerate(self.freq_bands.values()):
+        band_powers = np.zeros(shape=(len(self.FREQ_BANDS), powers.shape[-1]))
+        for band_idx, (min_freq, max_freq) in enumerate(self.FREQ_BANDS.values()):
             freq_mask = np.logical_and(freqs >= min_freq, freqs <= max_freq)
-            band_powers[:, band_idx] = simpson(
-                powers[:, freq_mask], dx=freq_res, axis=-1
-            )
+            # integrate over frequencies, average over channels
+            band_powers[band_idx, :] = simpson(
+                powers[:, freq_mask, :], dx=freq_res, axis=1
+            ).mean(axis=0)
 
         if self.relative:
-            total_powers = band_powers.sum(axis=-1).reshape(-1, 1)
-            band_powers /= total_powers
+            band_powers /= band_powers.sum(axis=0)
 
         return band_powers

--- a/aeon_neuro/transformations/tests/test_bandpower.py
+++ b/aeon_neuro/transformations/tests/test_bandpower.py
@@ -6,35 +6,40 @@ import pytest
 from aeon_neuro.transformations import bandpower
 
 # set paramaters, assuming X ~ iid = flat PSD
-n_cases, n_channels, n_timepoints = 2, 3, 10000
-freq_bands = {
-    "delta": (0, 4),
-    "theta": (4, 7),
-    "alpha": (8, 12),
-    "beta": (13, 30),
-    "gamma": (30, 60),
-}
-power_bands_expected = [
-    (max_freq - min_freq) for (min_freq, max_freq) in freq_bands.values()
-]
+n_channels, n_timepoints = 3, 10000
 
 
 @pytest.fixture
 def sim_X():
     """Simulate X ~ iid = flat PSD."""
     rng = np.random.default_rng(seed=0)
-    return rng.standard_normal(size=(n_cases, n_channels, n_timepoints))
+    return rng.standard_normal(size=(n_channels, n_timepoints))  # axis=1
 
 
 def test_transform(sim_X):
-    """Test BandpowerExtraction.transform method."""
+    """Test BandPowerSeriesTransformer."""
     X = sim_X
-    bpe = bandpower.BandpowerExtraction(
-        band="delta", fs=256, window_width=5120, window_space=10
+    transformer = bandpower.BandPowerSeriesTransformer(
+        sfreq=256, n_per_seg=1024, n_overlap=512, relative=True
     )
-    power_bands = []
-    for band in freq_bands.keys():
-        bpe.band = band
-        power_bands.append(bpe.transform(X).mean())
-    ratios = np.array(power_bands) / np.array(power_bands_expected)
-    np.testing.assert_allclose(ratios, ratios[0], rtol=0.01)
+
+    # estimated power bands
+    power_bands = transformer.fit_transform(X)
+    # check array and shape
+    assert isinstance(power_bands, np.ndarray)
+    assert power_bands.shape == (n_channels, 5)
+    # check relative=True, so powers sum to 1
+    np.testing.assert_equal(power_bands.sum(axis=-1), np.ones(shape=n_channels))
+
+    # expected power bands
+    power_bands_expected = np.array(
+        [
+            (max_freq - min_freq)
+            for (min_freq, max_freq) in transformer.freq_bands.values()
+        ],
+        dtype=np.float64,
+    )
+    power_bands_expected /= power_bands_expected.sum()
+    power_bands_expected = np.tile(power_bands_expected, (n_channels, 1))
+    # check expected power bands for iid = flat PSD
+    np.testing.assert_allclose(power_bands, power_bands_expected, atol=0.03)

--- a/aeon_neuro/transformations/tests/test_bandpower.py
+++ b/aeon_neuro/transformations/tests/test_bandpower.py
@@ -1,0 +1,40 @@
+"""Tests for bandpower."""
+
+import numpy as np
+import pytest
+
+from aeon_neuro.transformations import bandpower
+
+# set paramaters, assuming X ~ iid = flat PSD
+n_cases, n_channels, n_timepoints = 2, 3, 10000
+freq_bands = {
+    "delta": (0, 4),
+    "theta": (4, 7),
+    "alpha": (8, 12),
+    "beta": (13, 30),
+    "gamma": (30, 60),
+}
+power_bands_expected = [
+    (max_freq - min_freq) for (min_freq, max_freq) in freq_bands.values()
+]
+
+
+@pytest.fixture
+def sim_X():
+    """Simulate X ~ iid = flat PSD."""
+    rng = np.random.default_rng(seed=0)
+    return rng.standard_normal(size=(n_cases, n_channels, n_timepoints))
+
+
+def test_transform(sim_X):
+    """Test BandpowerExtraction.transform method."""
+    X = sim_X
+    bpe = bandpower.BandpowerExtraction(
+        band="delta", fs=256, window_width=5120, window_space=10
+    )
+    power_bands = []
+    for band in freq_bands.keys():
+        bpe.band = band
+        power_bands.append(bpe.transform(X).mean())
+    ratios = np.array(power_bands) / np.array(power_bands_expected)
+    np.testing.assert_allclose(ratios, ratios[0], rtol=0.01)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #46

#### What does this implement/fix? Explain your changes.
- add documentation and testing
- rewrite class to inherit from `BaseSeriesTransformer`
- calculate band power using `mne.time_frequency.psd_array_welch` which applies windowing to reduce spectral leakage
- estimate power over segments/windows and average over channels, so (n_channels, n_timepoints) -> (5_bands, n_timepoints/n_per_seg)

#### Does your contribution introduce a new dependency? If yes, which one?
None


### PR checklist

##### For all contributions
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.

