### PR TITLE
[BUG] BandPowerSeriesTransformer error

### DIFF
--- a/aeon_neuro/transformations/_bandpower.py
+++ b/aeon_neuro/transformations/_bandpower.py
@@ -21,7 +21,7 @@ class BandPowerSeriesTransformer(BaseSeriesTransformer):
     Parameters
     ----------
     sfreq : int or float
-        Sampling frequency in Hz, by default 1.0.
+        Sampling frequency in Hz, by default 120.
     n_per_seg : int, optional
         Length of each segment/window in number of timepoints, by default 256.
     window : str, optional
@@ -32,6 +32,11 @@ class BandPowerSeriesTransformer(BaseSeriesTransformer):
         If False, return the absolute power in V^2/Hz, by default True.
     n_jobs : int, optional
         Number of jobs to calculate power spectral densities, by default 1.
+
+    Raises
+    ------
+    ValueError
+        If sfreq is too low to capture power within each frequency band.
     """
 
     _tags = {
@@ -49,13 +54,18 @@ class BandPowerSeriesTransformer(BaseSeriesTransformer):
 
     def __init__(
         self,
-        sfreq=1.0,  # scipy default
+        sfreq=120,  # 2x60Hz = 120Hz
         n_per_seg=256,  # mne/scipy default, for window=str
         window="hamming",  # mne default
         relative=True,
         n_jobs=1,
     ):
         super().__init__(axis=1)  # (n_channels, n_timepoints)
+        nyquist_freq = 2 * self.FREQ_BANDS["gamma"][1]
+        if sfreq < nyquist_freq:
+            raise ValueError(
+                f"Sampling frequency (sfreq) must be at least {nyquist_freq} Hz."
+            )
         self.sfreq = sfreq
         self.n_per_seg = n_per_seg
         self.window = window

--- a/aeon_neuro/transformations/_bandpower.py
+++ b/aeon_neuro/transformations/_bandpower.py
@@ -104,6 +104,7 @@ class BandPowerSeriesTransformer(BaseSeriesTransformer):
             n_jobs=self.n_jobs,
             average=None,
             window=self.window,
+            verbose="error",
         )
 
         freq_res = freqs[1] - freqs[0]

--- a/aeon_neuro/transformations/_bandpower.py
+++ b/aeon_neuro/transformations/_bandpower.py
@@ -37,6 +37,7 @@ class BandPowerSeriesTransformer(BaseSeriesTransformer):
     ------
     ValueError
         If sfreq is too low to capture power within each frequency band.
+        If n_per_seg is less than half the sampling frequency.
     """
 
     _tags = {
@@ -66,6 +67,9 @@ class BandPowerSeriesTransformer(BaseSeriesTransformer):
             raise ValueError(
                 f"Sampling frequency (sfreq) must be at least {nyquist_freq} Hz."
             )
+        min_n = sfreq // 2
+        if n_per_seg < min_n:
+            raise ValueError(f"n_per_seg must be at least {min_n} for lowest freqs.")
         self.sfreq = sfreq
         self.n_per_seg = n_per_seg
         self.window = window

--- a/aeon_neuro/transformations/tests/test_bandpower.py
+++ b/aeon_neuro/transformations/tests/test_bandpower.py
@@ -52,10 +52,16 @@ def test_transform_nyquist():
     """Test BandPowerSeriesTransformer above/below nyquist."""
     rng = np.random.default_rng(seed=0)
     X = rng.random((32, 1000))
-    transformer = BandPowerSeriesTransformer()  # sfreq = 120
+    transformer = BandPowerSeriesTransformer()  # sfreq = 120, n_per_seg = 256
     transformer.fit_transform(X)
 
     with pytest.raises(
         ValueError, match="Sampling frequency .* must be at least .* Hz."
     ):
-        transformer.set_params(sfreq=100)
+        BandPowerSeriesTransformer(sfreq=119)
+
+    with pytest.raises(
+        ValueError,
+        match="n_per_seg must be at least .* for lowest freqs.",
+    ):
+        BandPowerSeriesTransformer(sfreq=120, n_per_seg=59)

--- a/aeon_neuro/transformations/tests/test_bandpower.py
+++ b/aeon_neuro/transformations/tests/test_bandpower.py
@@ -46,3 +46,16 @@ def test_transform(sim_X):
     )
     # check expected power bands for iid = flat PSD
     np.testing.assert_allclose(power_bands, power_bands_expected, atol=0.05)
+
+
+def test_transform_nyquist():
+    """Test BandPowerSeriesTransformer above/below nyquist."""
+    rng = np.random.default_rng(seed=0)
+    X = rng.random((32, 1000))
+    transformer = BandPowerSeriesTransformer()  # sfreq = 120
+    transformer.fit_transform(X)
+
+    with pytest.raises(
+        ValueError, match="Sampling frequency .* must be at least .* Hz."
+    ):
+        transformer.set_params(sfreq=100)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #79 

#### What does this implement/fix? Explain your changes.
- rename n_per_seg -> window_size and window -> window_function
- add stride argument so that n_overlap = window_size - stride
- change default sampling frequency (sfreq) to be greater than nyquist for gamma band
- raise ValueError if sfreq is too low to capture power at all bands
- raise ValueError if window_size (relative to sfreq) is too low to capture power at all bands
- raise ValueError if stride is not between 1 and window_size

#### Does your contribution introduce a new dependency? If yes, which one?
None


### PR checklist


##### For all contributions
- [x] The PR title starts with either [ENH], [MNT], [DOC], [BUG], [REF], [DEP] or [GOV] indicating whether the PR topic is related to enhancement, maintenance, documentation, bugs, refactoring, deprecation or governance.
